### PR TITLE
tech(forms): enable forms modules

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,8 +1,9 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 
 import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
+import { AppComponent } from './app.component'; 
 
 @NgModule({
   declarations: [
@@ -10,7 +11,10 @@ import { AppComponent } from './app.component';
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    FormsModule,
+    ReactiveFormsModule
+
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
Fixes #2 

Add both Template Driven and Reactive Forms to the application

- Template Driven Forms use `FormsModule`
- Reactive Forms use `ReactiveFormsModule`

Let us use ReactiveFormsModule to have more control over the component(ts) instead of the template file.

```js
import { FormsModule, ReactiveFormsModule } from '@angular/forms'

@NgModule({
  ...
  imports: [
   ...  
     FormsModule,
     ReactiveFormsModule
  ],
  ...
})
```