### PR TITLE
tech(module): add shared module

### DIFF
--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule
+  ]
+})
+export class SharedModule { }


### PR DESCRIPTION
## Issue ID : #9
Fixes #9 

## Summary

Creating shared modules allows you to organize and streamline your code. You can put commonly used directives, pipes, and components into one module and then import just that module wherever you need it in other parts of your app.

## Steps to do this Tech Update

- Angular CLI - `ng g m shared`
  - Creates - `CREATE src/app/shared/shared.module.ts (192 bytes)`

## Checklist

- [x] Have you added the summary of what your changes do and why you'd like us to include them?
- [x] Have you added the steps you followed?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the files been linted and formatted?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the need for this tech update, and the steps to reproduce the issue?
Best practice 

### What is the current status?
Created a module

### How does this PR fix the problem, Screenshot Please?
Not related to UI, it simply creates a file and folder `CREATE src/app/shared/shared.module.ts (192 bytes)`