### PR TITLE
tech(component/header): add shared header component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,2 @@
-<header class="border-b md:flex md:items-center md:justify-between p-4 pb-0 shadow-lg md:pb-4">
-  Tailwind Styled header goes here, Can be Removed
-</header>
-
+<app-header></app-header>
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { NotFoundComponent } from './not-found/not-found.component'; 
+import { SharedModule } from './shared/shared.module';
 
 @NgModule({
   declarations: [
@@ -15,8 +16,8 @@ import { NotFoundComponent } from './not-found/not-found.component';
     BrowserModule,
     AppRoutingModule,
     FormsModule,
-    ReactiveFormsModule
-
+    ReactiveFormsModule,
+    SharedModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -1,0 +1,3 @@
+<header class="border-b md:flex md:items-center md:justify-between p-4 pb-0 shadow-lg md:pb-4">
+    Tailwind Styled header goes here, Can be Removed - from Header Component
+</header>

--- a/src/app/shared/header/header.component.spec.ts
+++ b/src/app/shared/header/header.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HeaderComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss']
+})
+export class HeaderComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,12 +1,16 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-
+import { HeaderComponent } from './header/header.component';
 
 @NgModule({
-  declarations: [],
+  declarations: [
+    HeaderComponent
+  ],
   imports: [
     CommonModule
+  ],
+  exports:[
+    HeaderComponent
   ]
 })
 export class SharedModule { }


### PR DESCRIPTION
## Issue ID #20 

Fixes #20  

## Summary

Created a shared Header component for the application and which will be organized inside the Shared module under the shared folder.

## Steps to do this Tech Update

angular-cli

```
ng g c shared/header
```
```
CREATE src/app/shared/header/header.component.scss (0 bytes)
CREATE src/app/shared/header/header.component.html (21 bytes)
CREATE src/app/shared/header/header.component.spec.ts (626 bytes)
CREATE src/app/shared/header/header.component.ts (276 bytes)
UPDATE src/app/shared/shared.module.ts (276 bytes)
```
To provide access to the app module add the component into 'exports' array of the `SharedModule` decorator

```js
 exports:[
    HeaderComponent
  ]
```
To  access from the app module include `SharedModule` to import array of `AppModule` decorator

```js
  imports: [
     ....
    SharedModule
  ],
```
## Checklist

- [x] Have you added the summary of what your changes do and why you'd like us to include them?
- [x] Have you added the steps you followed?
- [ ] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the need for this tech update, and the steps to reproduce the issue?
To organize the components inside the Shared module under the shared folder.

### What is the current status?
Created a component and yet to work on the UI

### How does this PR fix the problem, Screenshot Please?
![image](https://user-images.githubusercontent.com/3478542/117419588-63aa4800-af3a-11eb-9cdc-92dd70e14240.png)
